### PR TITLE
add flag to print events to console

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,9 @@ program.command('test')
     .argument('[test_path]', 'path to test files', 'test/')
     .option("-s,--seed <uint32>", 'fuzzing PRNG seed', '0')
     .option("-r,--reps <string>", 'fuzzing repetitions', '1')
+    .option('-h, --hiss', 'print all events to console')
     .action((src_path, test_path, options) => {
-        test(src_path, test_path, program.opts().outputDir, options.seed, options.reps)
+        test(src_path, test_path, program.opts().outputDir, options.seed, options.reps, options.hiss)
     })
 
 program.addHelpText('after', `
@@ -47,14 +48,14 @@ const make = (path, output_dir, output_id) => {
     vyper.compile(path, output_dir, output_id)
 }
 
-const test = async (src_path, test_path, output_dir, seed, reps) => {
+const test = async (src_path, test_path, output_dir, seed, reps, hiss) => {
     network.start()
     try {
         make(src_path, output_dir, 'Src')
         make(test_path, output_dir, 'Test')
         make(resolve(__dirname, './snek.vy'), output_dir, 'Snek')
         await network.ready()
-        await runner.run(output_dir, seed, reps)
+        await runner.run(output_dir, seed, reps, hiss)
     } catch(e) {
         console.log(e)
     } finally {

--- a/src/runner.js
+++ b/src/runner.js
@@ -7,7 +7,7 @@ const { send } = require('minihat')
 
 module.exports = runner = {}
 
-runner.run = async (output_dir, seed, reps) => {
+runner.run = async (output_dir, seed, reps, hiss) => {
     const provider = new ethers.providers.JsonRpcProvider()
     const signer = provider.getSigner()
     const multifab_pack = require('../lib/multifab/pack/multifab_hardhat.dpack.json')
@@ -45,8 +45,8 @@ runner.run = async (output_dir, seed, reps) => {
                 try {
                     ran++
                     const args = func.inputs.length > 0 ? [test[func.name], reps] : [test[func.name]]
-                    const test_tx = await send(...args)
-                    runner.scan(test_tx, snek.address)
+                    const test_tx = await send(...args, {gasLimit: 100000000})
+                    runner.scan(test_tx, snek.address, hiss)
                     passed++
                     console.log(`${contract_name}::${func.name} ${chalk.green('PASSED')}`)
                 } catch (e) {
@@ -60,7 +60,7 @@ runner.run = async (output_dir, seed, reps) => {
     console.log(`Passed ${format(`${passed}/${ran}`)}`)
 }
 
-runner.scan = (test_tx, snek_addr) => {
+runner.scan = (test_tx, snek_addr, hiss) => {
     const sent = []
     const addr_eq =(a1, a2)=> a1.slice(-40).toLowerCase() === a2.slice(-40).toLowerCase()
     let target = "0"
@@ -77,6 +77,7 @@ runner.scan = (test_tx, snek_addr) => {
                 sent.shift()
             }
         }
+        if (hiss) console.log(`${event.eventSignature}, topics: ${event.topics.slice(1)}, address: ${event.address}`)
     }
     if (sent.length != 0) throw `Missing ${sent[0].event} echo`
 }


### PR DESCRIPTION
This was useful when testing multisig, doesn't necessarily make sense to add to snek and this can be rejected if you don't think it's useful.

In practice vyper print() is flaky when used with snek. Doesn't work with anvil, and only some types work with hardhat right now.