### PR TITLE
Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "initialize": "npm i && npm run download-submodules && npm run install-submodules",
     "download-submodules": "git submodule update --init --recursive --remote",
     "install-submodules": "cd lib/multifab && npm i && npm run pretest",
-    "test": "cd test && node ../index.js test",
-    "test-snek": "npx mocha test test/snek",
+    "test-int": "cd test && node ../index.js test",
+    "test-unit": "node test/snek/snek-test.js",
     "build-general": "pkg -t node16 index.js --output snek --config package.json",
     "build-linux": "npm run build-general && sudo cp -f ./snek /usr/local/bin"
   },
@@ -29,7 +29,6 @@
     "tapzero": "^0.6.1"
   },
   "devDependencies": {
-    "@types/mocha": "^9.1.1",
     "pkg": "^5.7.0"
   }
 }

--- a/src/runner.js
+++ b/src/runner.js
@@ -47,6 +47,7 @@ runner.run = async (output_dir, seed, reps, hiss) => {
         }
     }
 
+    // let tapzero clear test task queue, otherwise snek will tear down network early
     while (!GLOBAL_TEST_RUNNER.completed) {
         await new Promise(resolve => setTimeout(resolve, 10))
     }

--- a/src/runner.js
+++ b/src/runner.js
@@ -25,8 +25,7 @@ runner.run = async (output_dir, seed, reps, hiss) => {
     buff.writeUInt32BE(seed, 0)
     const snek_output = require(resolve(`${output_dir}/SnekOutput.json`))
     const snek_contract = Object.values(snek_output.contracts)[0]['snek']
-    const snek_interface = new ethers.utils.Interface(snek_contract.abi)
-    const snek_factory = new ethers.ContractFactory(snek_interface, snek_contract.evm.bytecode.object, signer)
+    const snek_factory = new ethers.ContractFactory(snek_contract.abi, snek_contract.evm.bytecode.object, signer)
     const snek = await snek_factory.deploy(multifab.address, buff)
 
     for ([contract_name, contract] of src_contracts) {
@@ -36,8 +35,7 @@ runner.run = async (output_dir, seed, reps, hiss) => {
     }
 
     for ([contract_name, contract] of tst_contracts) {
-        const iface = new ethers.utils.Interface(contract.abi)
-        const factory = new ethers.ContractFactory(iface, contract.evm.bytecode.object, signer)
+        const factory = new ethers.ContractFactory(contract.abi, contract.evm.bytecode.object, signer)
         const suite = await factory.deploy(snek.address)
         for (const func of contract.abi) {
             if ('name' in func && func.name.startsWith(test_prefix)) {
@@ -67,9 +65,10 @@ runner.exec = async (func, suite, reps, snek, hiss, contract_name, t) => {
     if (want_pass === (typeof error === 'undefined')) {
         t.ok(true, `${contract_name}::${func.name}`)
     } else {
-        let err_msg = error
-        if(typeof error === 'undefined') {
-            err_msg = 'No exception'
+        let err_msg = 'Missing exception'
+        if(typeof error !== 'undefined') {
+            let code = await suite.provider.call(error.transaction, error.transaction.blockNumber)
+            err_msg = ethers.utils.toUtf8String('0x' + code.slice(138))
         }
         t.fail(err_msg)
     }

--- a/test/snek/test-harness.js
+++ b/test/snek/test-harness.js
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+
+const fs = require('fs')
+
+const ethers = require('ethers')
+const tapzero = require('tapzero');
+const testHarness = require('tapzero/harness');
+
+const network = require("../../src/network");
+const vyper = require("../../src/vyper");
+
+const vars = {raw: true}
+
+class TestHarness {
+    async bootstrap() {
+        if (vars.raw) {
+            network.start()
+            vars.dir = `${__dirname}/SnekTest`
+            const provider = new ethers.providers.JsonRpcProvider()
+            vars.signer = provider.getSigner()
+            vyper.compile('snek.vy', vars.dir, 'Snek')
+            const snek_output = require(`${vars.dir}/SnekOutput.json`)
+            const snek_contract = Object.values(snek_output.contracts)[0]['snek']
+            const snek_factory = new ethers.ContractFactory(
+                snek_contract.abi, snek_contract.evm.bytecode.object, vars.signer)
+            const multifab_factory = ethers.ContractFactory.fromSolidity(
+                require('../../lib/multifab/artifacts/core/multifab.sol/Multifab.json'), vars.signer)
+            await network.ready()
+            vars.multifab = await multifab_factory.deploy()
+            vars.snek = await snek_factory.deploy(vars.multifab.address, Buffer.alloc(32))
+            vars.raw = false
+        }
+        Object.assign(this, vars)
+    }
+
+    async close() {
+        setTimeout(() => {
+            if (tapzero.GLOBAL_TEST_RUNNER.completed) {
+                fs.rmSync(this.dir, {recursive: true, force: true})
+                network.exit()
+            }
+        }, 0)
+    }
+}
+
+TestHarness.test = testHarness(tapzero, TestHarness)
+module.exports = TestHarness

--- a/test/src/Snake.vy
+++ b/test/src/Snake.vy
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: AGPL-3.0
+
+size: public(uint256)
+
+@external
+def __init__(_size: uint256):
+    self.size = _size
+
+@external
+def grow():
+    self.size += 1

--- a/test/test/person.t.vy
+++ b/test/test/person.t.vy
@@ -40,27 +40,27 @@ def __init__(_snek: Snek):
 
 @external
 def test_name():
-    assert self.prs1.name() == 'ali'
+    assert self.prs1.name() == 'ali', 'unexpected prs1 name'
 
 @external
 def test_throw_name():
-    assert self.prs1.name() == 'bob'
+    assert self.prs1.name() == 'bob', 'correct exception'
 
 @external
 def test_set_name():
     self.prs1.set_name('cat')
-    assert self.prs1.name() == 'cat'
+    assert self.prs1.name() == 'cat', 'setting name failed'
 
 @external
 def test_year():
-    assert self.prs1.year() == 10
+    assert self.prs1.year() == 10, 'unexpected prs1 year'
 
 @external
 def test_set_year():
     self.snek.echo(self.prs1.address)
     log Birth(20)
     self.prs1.set_year(20)
-    assert self.prs1.year() == 20
+    assert self.prs1.year() == 20, 'setting year failed'
 
 @external
 def test_events():
@@ -92,4 +92,4 @@ def test_fuzz(reps: uint256):
         elif opt == 2:
             self.prs1.shop(self.snek.rand(self.prs1.cash() + 1))
         
-        assert self.prs1.debt() == self.prs1.cash() + self.prs1.toys()
+        assert self.prs1.debt() == self.prs1.cash() + self.prs1.toys(), 'debt invariant broken'

--- a/test/test/snake.t.vy
+++ b/test/test/snake.t.vy
@@ -1,0 +1,25 @@
+# tiny extra test to ensure snek works with multiple contracts
+
+interface Snek:
+    def make(typename: String[32], objectname: String[32], args: Bytes[3200]) -> address: nonpayable
+    def echo(target: address): nonpayable
+    def rand(set: uint256) -> uint256: nonpayable
+
+interface Snake:
+    def grow(): nonpayable
+    def size() -> uint256: view
+
+sean: public(Snake)
+snek: public(Snek)
+
+@external
+def __init__(_snek: Snek):
+    size: uint256 = 10
+    args: Bytes[32] = _abi_encode(size)
+    self.snek = _snek
+    self.sean = Snake(self.snek.make('Snake', 'snake1', args))
+
+@external
+def test_grow():
+    self.sean.grow()
+    assert self.sean.size() == 11, 'size not equal'

--- a/test/test/snake.t.vy
+++ b/test/test/snake.t.vy
@@ -22,4 +22,4 @@ def __init__(_snek: Snek):
 @external
 def test_grow():
     self.sean.grow()
-    assert self.sean.size() == 11, 'size not equal'
+    assert self.sean.size() == 11, 'unexpected size after grow'


### PR DESCRIPTION
removes mocha
adds a tapzero test harness with a pattern for equivalent to "before all" and "after all"
integration tests ensure multiple contracts work as expected
uses ethers provider.call so snek can display vyper error strings after failed tests