### PR TITLE
Update multifab

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/multifab"]
 	path = lib/multifab
-	url = https://github.com/ricobank/multifab
+	url = https://github.com/ricobank/multifab.git

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "initialize": "npm i && npm run download-submodules && npm run install-submodules",
-    "download-submodules": "git submodule update --init --recursive --remote",
+    "download-submodules": "git submodule update --init --recursive",
     "install-submodules": "cd lib/multifab && npm i && npm run pretest",
     "test-int": "cd test && node ../index.js test",
     "test-unit": "node test/snek/snek-test.js",

--- a/snek.vy
+++ b/snek.vy
@@ -24,16 +24,14 @@
 
 # https://github.com/ricobank/multifab
 interface Multifab:
-    def cache(code: Bytes[20000000]) -> bytes32:  # max size, typed as `bytes` in ABI
-        nonpayable
-    def build(hash: bytes32, args :Bytes[20000000]) -> address:
-        nonpayable
+    def build(blueprint: address, args: Bytes[4096]) -> address: nonpayable
+    def built(arg0: address) -> address: view
 
 event Echo:
     target: indexed(address)
 
 fab: Multifab
-types: public(HashMap[String[32], bytes32])
+types: public(HashMap[String[32], address])
 seed: bytes32
 
 @external
@@ -43,20 +41,20 @@ def __init__(fab: address, seed: bytes32):
     self.seed = seed
 
 @external
-def _bind(typename: String[32], _hash: bytes32):
+def _bind(typename: String[32], blueprint: address):
     """ _bind is called by this test framework to associate typenames with
         codehashes so that `snek.make` can use a string typename
     """
-    self.types[typename] = _hash
+    self.types[typename] = blueprint
 
 @external
 def make(typename: String[32], args: Bytes[3200]) -> address:
     """ make calls `fab.build` with the right codehash based on typename,
         then it saves the object with the given objectname for reference
     """
-    type_hash: bytes32 = self.types[typename]
-    assert type_hash != empty(bytes32), 'unknown type'
-    _object: address = self.fab.build(type_hash, args)
+    blueprint: address = self.types[typename]
+    assert blueprint != empty(address), 'unknown type'
+    _object: address = self.fab.build(blueprint, args)
     assert _object != empty(address), 'failed to make type'
     return _object
 

--- a/snek.vy
+++ b/snek.vy
@@ -34,7 +34,6 @@ event Echo:
 
 fab: Multifab
 types: public(HashMap[String[32], bytes32])
-objects: public(HashMap[String[32], address])
 seed: bytes32
 
 @external
@@ -51,7 +50,7 @@ def _bind(typename: String[32], _hash: bytes32):
     self.types[typename] = _hash
 
 @external
-def make(typename: String[32], objectname: String[32], args: Bytes[3200]) -> address:
+def make(typename: String[32], args: Bytes[3200]) -> address:
     """ make calls `fab.build` with the right codehash based on typename,
         then it saves the object with the given objectname for reference
     """
@@ -59,7 +58,6 @@ def make(typename: String[32], objectname: String[32], args: Bytes[3200]) -> add
     assert type_hash != empty(bytes32), 'unknown type'
     _object: address = self.fab.build(type_hash, args)
     assert _object != empty(address), 'failed to make type'
-    self.objects[objectname] = _object
     return _object
 
 @external

--- a/src/vyper.js
+++ b/src/vyper.js
@@ -1,7 +1,7 @@
 const execSync = require('node:child_process').execSync
 const process = require('node:process')
 const fs = require('fs')
-const path = require('path');
+const path = require('path')
 
 module.exports = vy = {}
 

--- a/test/snek/snek-test.js
+++ b/test/snek/snek-test.js
@@ -1,28 +1,30 @@
 const { send } = require('minihat')
 const ethers = require('ethers')
+
+const bp = require('../../src/blueprint.js')
 const vyper = require('../../src/vyper.js')
 const TestHarness = require('./test-harness')
 
-TestHarness.test('should bind hash correctly', async (harness, assert) => {
+TestHarness.test('should bind address correctly', async (harness, assert) => {
     const test_type = "test_type"
-    const test_hash = ethers.utils.formatBytes32String("testhash")
-    await harness.snek._bind(test_type, test_hash)
-    assert.equal(await harness.snek.types(test_type), test_hash)
+    await harness.snek._bind(test_type, harness.multifab.address)
+    assert.equal(await harness.snek.types(test_type), harness.multifab.address)
 })
 
 TestHarness.test('should be able to make an object', async (harness, assert) => {
     vyper.compile('test/src/Person.vy', harness.dir, 'Person')
     const person_output = require(`${harness.dir}/PersonOutput.json`)
-    const person_contract = Object.values(person_output.contracts)[0]['Person']
-    const cache_tx = await send(harness.multifab.cache, person_contract.evm.bytecode.object)
-    const [, person_hash] = cache_tx.events.find(event => event.event === 'Added').args
-    await harness.snek._bind('Person', person_hash)
-    assert.equal(await harness.snek.types('Person'), person_hash)
+    const person_data = Object.values(person_output.contracts)[0]['Person']
+    const blueprint = bp.generate(person_data.evm.bytecode.object)
+    const factory = new ethers.ContractFactory([], blueprint, harness.signer)
+    const contract = await factory.deploy({gasLimit: 100000000})
+    await send(harness.snek._bind, 'Person', contract.address)
+    assert.equal(await harness.snek.types('Person'), contract.address)
 
     const person_args = ethers.utils.defaultAbiCoder.encode(['string', 'string', 'uint256'], ["Rico", "Bank", 2022])
     const receipt = await send(harness.snek.make, 'Person', person_args)
-    const [, , person_address ] = receipt.events.find(event => event.address === harness.multifab.address).topics
-    const person = new ethers.Contract('0x' + person_address.slice(2 + 12*2), person_contract.abi, harness.signer)
+    const [, , , person_address] = receipt.events.find(event => event.address === harness.multifab.address).topics
+    const person = new ethers.Contract('0x' + person_address.slice(2 + 12*2), person_data.abi, harness.signer)
     assert.equal(await person.name(), "Rico")
     assert.equal(await person.last(), "Bank")
     assert.equal(parseInt(await person.year()), 2022)

--- a/test/snek/snek-test.js
+++ b/test/snek/snek-test.js
@@ -20,9 +20,9 @@ TestHarness.test('should be able to make an object', async (harness, assert) => 
     assert.equal(await harness.snek.types('Person'), person_hash)
 
     const person_args = ethers.utils.defaultAbiCoder.encode(['string', 'string', 'uint256'], ["Rico", "Bank", 2022])
-    await send(harness.snek.make, 'Person', 'person1', person_args)
-    const person_address = await harness.snek.objects('person1')
-    const person = new ethers.Contract(person_address, person_contract.abi, harness.signer)
+    const receipt = await send(harness.snek.make, 'Person', person_args)
+    const [, , person_address ] = receipt.events.find(event => event.address === harness.multifab.address).topics
+    const person = new ethers.Contract('0x' + person_address.slice(2 + 12*2), person_contract.abi, harness.signer)
     assert.equal(await person.name(), "Rico")
     assert.equal(await person.last(), "Bank")
     assert.equal(parseInt(await person.year()), 2022)

--- a/test/snek/test-harness.js
+++ b/test/snek/test-harness.js
@@ -18,15 +18,19 @@ class TestHarness {
             vars.dir = `${__dirname}/SnekTest`
             const provider = new ethers.providers.JsonRpcProvider()
             vars.signer = provider.getSigner()
+
             vyper.compile('snek.vy', vars.dir, 'Snek')
             const snek_output = require(`${vars.dir}/SnekOutput.json`)
             const snek_contract = Object.values(snek_output.contracts)[0]['snek']
             const snek_factory = new ethers.ContractFactory(
                 snek_contract.abi, snek_contract.evm.bytecode.object, vars.signer)
-            const multifab_factory = ethers.ContractFactory.fromSolidity(
-                require('../../lib/multifab/artifacts/core/multifab.sol/Multifab.json'), vars.signer)
+
+            const mf_src_output = require(`../../lib/multifab/out/SrcOutput.json`)
+            const mf_contract = mf_src_output.contracts["src/Multifab.vy"].Multifab
+            const mf_factory = new ethers.ContractFactory(mf_contract.abi, mf_contract.evm.bytecode.object, vars.signer)
+
             await network.ready()
-            vars.multifab = await multifab_factory.deploy()
+            vars.multifab = await mf_factory.deploy()
             vars.snek = await snek_factory.deploy(vars.multifab.address, Buffer.alloc(32))
             vars.raw = false
         }

--- a/test/src/test/Hydra.vy
+++ b/test/src/test/Hydra.vy
@@ -6,7 +6,3 @@ size: public(uint256)
 @external
 def __init__(_size: uint256):
     self.size = _size
-
-@external
-def grow():
-    self.size += 1

--- a/test/test/person.t.vy
+++ b/test/test/person.t.vy
@@ -1,5 +1,5 @@
 interface Snek:
-    def make(typename: String[32], objectname: String[32], args: Bytes[3200]) -> address: nonpayable
+    def make(typename: String[32], args: Bytes[3200]) -> address: nonpayable
     def echo(target: address): nonpayable
     def rand(set: uint256) -> uint256: nonpayable
 
@@ -35,8 +35,8 @@ def __init__(_snek: Snek):
     last: String[32] = 'bob'
     year: uint256 = 10
     args: Bytes[224] = _abi_encode(name, last, year)
-    self.prs1 = Person(self.snek.make('Person', 'person1', args))
-    self.prs2 = Person(self.snek.make('Person', 'person2', args))
+    self.prs1 = Person(self.snek.make('Person', args))
+    self.prs2 = Person(self.snek.make('Person', args))
 
 @external
 def test_name():

--- a/test/test/snake.t.vy
+++ b/test/test/snake.t.vy
@@ -1,7 +1,7 @@
 # extra test to ensure snek works with multiple contracts at same level and recursively
 
 interface Snek:
-    def make(typename: String[32], objectname: String[32], args: Bytes[3200]) -> address: nonpayable
+    def make(typename: String[32], args: Bytes[3200]) -> address: nonpayable
     def echo(target: address): nonpayable
     def rand(set: uint256) -> uint256: nonpayable
 
@@ -22,8 +22,8 @@ def __init__(_snek: Snek):
     size: uint256 = 10
     args: Bytes[32] = _abi_encode(size)
     self.snek = _snek
-    self.sean = Snake(self.snek.make('Snake', 'snake1', args))
-    self.stan = Hydra(self.snek.make('Hydra', 'hydra2', args))
+    self.sean = Snake(self.snek.make('Snake', args))
+    self.stan = Hydra(self.snek.make('Hydra', args))
 
 @external
 def test_grow():


### PR DESCRIPTION
uses vyper multifab
snek works with blueprint addresses instead of hashes of cached code

easiest to remove submodule and then add again if you already have history pointing to sol repo

resolves #16